### PR TITLE
Add detailed spectral mixing documentation and comments

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,80 @@
+# Spectral Mixing Overview
+
+## 背景理論
+本リポジトリの`spectral.js`および`shader/spectral.glsl`は、顔料混色をモデル化するために**Kubelka–Munk理論**を採用しています。この理論は、拡散反射を行う薄層における光の吸収係数\(K\)と散乱係数\(S\)を扱い、反射率\(R\)と\(K/S\)比の間に以下の関係を与えます。
+
+\[
+K/S = \frac{(1 - R)^2}{2R}
+\]
+
+実装ではこの式を`KS(R)`として直接利用し、混色時には複数顔料の\(K/S\)比を濃度に応じて加重平均した後、Kubelka–Munkの逆変換
+
+\[
+R = 1 + \frac{K}{S} - \sqrt{\left(\frac{K}{S}\right)^2 + 2\frac{K}{S}}
+\]
+
+を`KM(KS)`として用いて再び反射率スペクトルに戻します。この近似は、顔料が完全拡散体として振る舞うという標準的なKubelka–Munk仮定に基づいており、塗料やインクの混色挙動を再現するための経験則です。
+
+## サンプリングと定数
+両ファイルはスペクトルを**38バンド**で表現します。これはおおよそ 380–780 nm を 10 nm 間隔でサンプリングした離散反射率ベクトルで、定数 `SIZE` (`SPECTRAL_SIZE`) に格納されています。sRGBとの相互変換では IEC 61966-2-1 に準拠したガンマ値 **2.4** (`GAMMA`, `SPECTRAL_GAMMA`) を用いたコンパンディング／アンコンパンディング式を採用しています。数値的不安定性を防ぐため、反射率には `Number.EPSILON` および GLSL 版の `SPECTRAL_EPSILON` を下限として適用しています。
+
+## 既知の基底スペクトル
+`spectral.js`内の`BASE_SPECTRA`とシェーダー内の対応する係数テーブルは、以下の7つの基底スペクトルを提供します。
+
+- **W**: 理想的な白のスペクトル
+- **C/M/Y**: シアン／マゼンタ／イエローの減法混色基底
+- **R/G/B**: sRGB原色の高彩度スペクトル
+
+線形RGBをスペクトルに変換する際は、線形RGB成分をホワイト、二色成分（C/M/Y）、一次成分（R/G/B）のウェイトに分解し、それぞれのスペクトルを線形結合して反射率ベクトル\(R_i\)を構築します。これにより、RGB色空間で与えられた入力でもスペクトル混色を行えるようになります。
+
+## CIE 表色系への変換
+スペクトル反射率は、D65標準光源で重み付けされた**CIE 1931 2° 標準等色関数** (`CIE.CMF`) を用いて XYZ に変換されます。
+
+\[
+\begin{bmatrix} X \\ Y \\ Z \end{bmatrix} = \mathrm{CMF} \cdot R
+\]
+
+得られた XYZ は行列 `CONVERSION.XYZ_RGB` を通じて線形RGBに変換され、さらにガンマ補正を施して8-bit sRGBを得ます。逆方向では `CONVERSION.RGB_XYZ` と OKLab 変換行列 (`XYZ_LMS`, `LMS_LAB` など) を利用し、OKLab/OKLCh 空間でのガムートマッピングや距離計算が行われます。
+
+## Kubelka–Munk 混色アルゴリズム
+### 1. 準備
+各 `Color` インスタンスまたはシェーダー内の色ベクトルは、まず `spectral_srgb_to_linear` で線形RGBに変換されます。次に `lRGB_to_R`/`spectral_linear_to_reflectance` が基底スペクトルを組み合わせて反射率ベクトルを生成します。
+
+### 2. 濃度とティンティング強度
+`spectral.js` の `mix` およびシェーダーの `spectral_mix` は、各色に対して次の「濃度」を計算します。
+
+\[
+C = f^2 \cdot t^2 \cdot Y
+\]
+
+ここで \(f\) はユーザが与える混合比、\(t\) は `tintingStrength`、\(Y\) はスペクトルから計算した輝度（CIE Y成分）です。二乗を用いることで濃度パラメータの寄与を増幅し、小さな比率の色でも影響が現れるように調整しています。
+
+### 3. KS の合成
+各波長サンプルについて、前述の濃度を重みとした加重平均を行います。
+
+\[
+(K/S)_\text{mix} = \frac{\sum_i (K/S)_i \cdot C_i}{\sum_i C_i}
+\]
+
+### 4. 反射率への逆変換
+得られた平均\(K/S\)を`KM`で反射率に戻し、新たなスペクトル反射率列`R`を得ます。最後に `spectral_reflectance_to_xyz` および `spectral_xyz_to_srgb` で可視色として出力します。
+
+## JavaScript 実装 (`spectral.js`)
+- **Color クラス**: CSSカラー文字列やsRGB配列からスペクトル表現までを双方向に変換し、OKLab/OKLCh 表色系、ガムート判定、ティンティング強度などを提供します。
+- **ガムートマッピング**: `gamutMap`はOKLChの彩度に対して二分探索を行い、`deltaEOK`でOKLab距離を監視しながらガムート外の色を安全にクリップします。
+- **ユーティリティ**: `utils` にはコンパンディング式、行列演算、線形補間などの数学的支援関数が集約されています。
+- **スペクトルデータ**: `BASE_SPECTRA` と `CIE` は immutable な定数として提供され、 Kubelka–Munk 計算と表色系変換の両方に再利用されます。
+
+## GLSL 実装 (`shader/spectral.glsl`)
+GLSL 版は JavaScript 実装と同じ計算を GPU 上で行えるよう、以下の主要関数を提供します。
+
+- `spectral_uncompand` / `spectral_compand`: sRGB と線形RGBの相互変換。
+- `spectral_linear_to_reflectance`: 基底スペクトルを用いた反射率生成。
+- `KS` / `KM`: Kubelka–Munk の正逆変換。
+- `spectral_reflectance_to_xyz`: CIE CMF によるXYZ積分。
+- `spectral_mix`: 2〜4色の混合に対応し、CPU版と同じ濃度計算・KS平均を実施。
+
+GLSL 内の配列定数は JavaScript 版と一致しており、CPU/ GPU 間で視覚的一貫性を保ちます。`SPECTRAL_EPSILON` を通じてゼロ除算を防ぎ、`clamp` による sRGB 出力の範囲保証を行っています。
+
+## まとめ
+両実装は Kubelka–Munk 理論に基づく物理指向の混色を採用し、スペクトルデータを介して sRGB 表示と OKLab/OKLCh ガムート制御を行います。豊富な定数と行列は CIE 標準および sRGB 変換規格に由来し、JavaScript と GLSL の両環境で同等の結果を得られるよう調整されています。

--- a/shader/spectral.glsl
+++ b/shader/spectral.glsl
@@ -23,15 +23,28 @@
 #ifndef SPECTRAL
 #define SPECTRAL
 
+// Number of wavelength samples used for the discretised reflectance curves.
+// The distribution mirrors the JavaScript implementation (roughly 10 nm steps
+// from 380 nm to 780 nm) so that CPU and GPU paths produce identical colours.
 const int SPECTRAL_SIZE = 38;
+// IEC 61966-2-1 transfer curve exponent used when converting between gamma
+// encoded sRGB values and their linear-light equivalents.
 const float SPECTRAL_GAMMA = 2.4;
+// Smallest allowed reflectance value to guard against divisions by zero in the
+// Kubelka–Munk equations when a band is fully absorbing.
 const float SPECTRAL_EPSILON = 0.0000000000000001;
 
 float spectral_uncompand(float x) {
+  // Piecewise sRGB inverse transfer function: linear segment near black and a
+  // power law segment elsewhere. This mirrors the CPU implementation so that
+  // the same input colours can be shared between environments.
   return (x < 0.04045) ? x / 12.92 : pow((x + 0.055) / 1.055, SPECTRAL_GAMMA);
 }
 
 float spectral_compand(float x) {
+  // Forward sRGB transfer function (linear -> non-linear). The output is not
+  // clamped here; clamping happens in spectral_linear_to_srgb once all channels
+  // are processed.
   return (x < 0.0031308) ? x * 12.92 : 1.055 * pow(x, 1.0 / SPECTRAL_GAMMA) - 0.055;
 }
 
@@ -48,14 +61,19 @@ void spectral_linear_to_reflectance(vec3 lrgb, inout float R[SPECTRAL_SIZE]) {
 
   lrgb -= w;
 
+  // Resolve the cyan, magenta and yellow contributions that can be expressed
+  // as the overlap of two primaries once the neutral component has been
+  // removed.
   float c = min(lrgb.g, lrgb.b);
   float m = min(lrgb.r, lrgb.b);
   float y = min(lrgb.r, lrgb.g);
 
+  // The remaining single-channel energy is mapped to the spectral basis for
+  // the red, green and blue primaries.
   float r = min(max(0.0, lrgb.r - lrgb.b), max(0.0, lrgb.r - lrgb.g));
   float g = min(max(0.0, lrgb.g - lrgb.b), max(0.0, lrgb.g - lrgb.r));
   float b = min(max(0.0, lrgb.b - lrgb.g), max(0.0, lrgb.b - lrgb.r));
-  
+
   R[ 0] = max(SPECTRAL_EPSILON, w * 1.0011607271876400 + c * 0.9705850013229620 + m * 0.9906735573199880 + y * 0.0210523371789306 + r * 0.0315605737777207 + g * 0.0095560747554212 + b * 0.9794047525020140);
   R[ 1] = max(SPECTRAL_EPSILON, w * 1.0011606515972800 + c * 0.9705924981434250 + m * 0.9906715249619790 + y * 0.0210564627517414 + r * 0.0315520718330149 + g * 0.0095581580120851 + b * 0.9794007068431300);
   R[ 2] = max(SPECTRAL_EPSILON, w * 1.0011603192274700 + c * 0.9706253487298910 + m * 0.9906625823534210 + y * 0.0210746178695038 + r * 0.0315148215513658 + g * 0.0095673245444588 + b * 0.9793829034702610);
@@ -156,10 +174,14 @@ vec3 spectral_reflectance_to_xyz(float R[SPECTRAL_SIZE]) {
 }
 
 float KS(float R) {
-	return pow(1.0 - R, 2.0) / (2.0 * R);
+  // Direct implementation of the Kubelka–Munk forward transform that
+  // converts a reflectance band into its absorption/scattering ratio.
+  return pow(1.0 - R, 2.0) / (2.0 * R);
 }
 
 float KM(float KS) {
+  // Inverse Kubelka–Munk transform: reconstructs a reflectance value from an
+  // averaged absorption/scattering ratio.
   return 1.0 + KS - sqrt(pow(KS, 2.0) + 2.0 * KS);
 }
 
@@ -181,13 +203,18 @@ vec3 spectral_mix(vec3 color1, float tintingStrength1, float factor1, vec3 color
   for (int i = 0; i < SPECTRAL_SIZE; i++) {
     float concentration1 = pow(factor1, 2.) * pow(tintingStrength1, 2.) * luminance1;
     float concentration2 = pow(factor2, 2.) * pow(tintingStrength2, 2.) * luminance2;
-		
-		float totalConcentration = concentration1 + concentration2;
-		
+
+    // Total pigment concentration for this wavelength sample. Using the sum as
+    // a denominator normalises the mixture so that the resulting reflectance
+    // remains between zero and one.
+    float totalConcentration = concentration1 + concentration2;
+
     float ksMix = 0.;
-		
-		ksMix += KS(R1[i]) * concentration1;
-		ksMix += KS(R2[i]) * concentration2;
+
+    // Accumulate the Kubelka–Munk K/S ratio for each pigment weighted by its
+    // concentration. This is equivalent to the additive rule for the KM model.
+    ksMix += KS(R1[i]) * concentration1;
+    ksMix += KS(R2[i]) * concentration2;
 
     R[i] = KM(ksMix / totalConcentration);
   }
@@ -226,14 +253,14 @@ vec3 spectral_mix(vec3 color1, float tintingStrength1, float factor1, vec3 color
     float concentration1 = pow(factor1, 2.) * pow(tintingStrength1, 2.) * luminance1;
     float concentration2 = pow(factor2, 2.) * pow(tintingStrength2, 2.) * luminance2;
     float concentration3 = pow(factor3, 2.) * pow(tintingStrength3, 2.) * luminance3;
-		
-		float totalConcentration = concentration1 + concentration2 + concentration3;
-		
+
+    float totalConcentration = concentration1 + concentration2 + concentration3;
+
     float ksMix = 0.;
-		
-		ksMix += KS(R1[i]) * concentration1;
-		ksMix += KS(R2[i]) * concentration2;
-		ksMix += KS(R3[i]) * concentration3;
+
+    ksMix += KS(R1[i]) * concentration1;
+    ksMix += KS(R2[i]) * concentration2;
+    ksMix += KS(R3[i]) * concentration3;
 
     R[i] = KM(ksMix / totalConcentration);
   }
@@ -273,15 +300,15 @@ vec3 spectral_mix(vec3 color1, float tintingStrength1, float factor1, vec3 color
     float concentration2 = pow(factor2, 2.) * pow(tintingStrength2, 2.) * luminance2;
     float concentration3 = pow(factor3, 2.) * pow(tintingStrength3, 2.) * luminance3;
     float concentration4 = pow(factor4, 2.) * pow(tintingStrength4, 2.) * luminance4;
-		
-		float totalConcentration = concentration1 + concentration2 + concentration3 + concentration4;
-		
+
+    float totalConcentration = concentration1 + concentration2 + concentration3 + concentration4;
+
     float ksMix = 0.;
-		
-		ksMix += KS(R1[i]) * concentration1;
-		ksMix += KS(R2[i]) * concentration2;
-		ksMix += KS(R3[i]) * concentration3;
-		ksMix += KS(R4[i]) * concentration4;
+
+    ksMix += KS(R1[i]) * concentration1;
+    ksMix += KS(R2[i]) * concentration2;
+    ksMix += KS(R3[i]) * concentration3;
+    ksMix += KS(R4[i]) * concentration4;
 
     R[i] = KM(ksMix / totalConcentration);
   }

--- a/spectral.js
+++ b/spectral.js
@@ -29,7 +29,13 @@
 })(this, function (exports) {
   ('use strict');
 
+  // Number of discrete wavelength samples used throughout the Kubelka–Munk
+  // calculations. The samples correspond to roughly 380–780 nm at 10 nm steps,
+  // matching the band structure of the spectral basis data below.
   const SIZE = 38;
+  // Gamma exponent for the sRGB transfer curve as defined by IEC 61966-2-1.
+  // Both the JavaScript implementation and the shader use this constant so
+  // that CPU and GPU conversions remain numerically consistent.
   const GAMMA = 2.4;
 
   /**
@@ -54,20 +60,33 @@
       if (args.length === 1) {
         if (typeof args[0] === 'string') {
           this.sRGB = parse(args[0]).slice(0, 3);
+          // Convert the encoded sRGB triplet into its linear-light form so
+          // that the subsequent Kubelka–Munk computations operate on physical
+          // intensities rather than gamma-encoded values.
           this.lRGB = sRGB_to_lRGB(this.sRGB);
+          // Project the linear RGB color onto the spectral basis functions to
+          // obtain a reflectance curve that can be mixed in the spectral domain.
           this.R = lRGB_to_R(this.lRGB);
+          // Accumulate the reflectance samples with the CIE color matching
+          // functions to obtain XYZ tristimulus values for downstream
+          // conversions and luminance queries.
           this.XYZ = R_to_XYZ(this.R);
         }
 
         if (Array.isArray(args[0])) {
           if (args[0].length === SIZE) {
             this.R = args[0];
+            // Skip the spectral reconstruction step and derive the tristimulus
+            // and sRGB representations directly from the provided reflectance.
             this.XYZ = R_to_XYZ(this.R);
             this.lRGB = XYZ_to_lRGB(this.XYZ);
             this.sRGB = lRGB_to_sRGB(this.lRGB);
           } else {
             this.sRGB = args[0];
             this.lRGB = sRGB_to_lRGB(this.sRGB);
+            // The linear RGB values can be interpreted as emissive primaries,
+            // but to reuse the Kubelka–Munk workflow we build a surrogate
+            // reflectance curve that approximates the same visible color.
             this.R = lRGB_to_R(this.lRGB);
             this.XYZ = R_to_XYZ(this.R);
           }
@@ -288,6 +307,8 @@
       current = XYZ_to_lRGB(XYZ);
 
       if (min_inGamut && inGamut(current)) {
+        // If the chroma candidate stays in gamut we expand the lower bound of
+        // the search interval. This preserves saturation whenever possible.
         min = chroma;
       } else {
         clipped = lRGB_to_OKLab(current.map((x) => utils.clamp(x)));
@@ -295,12 +316,16 @@
 
         if (E < jnd) {
           if (jnd - E < e) {
+            // The perceptual distance is below the threshold and further
+            // refinement would not yield a noticeable difference, so bail out.
             break;
           } else {
             min_inGamut = false;
             min = chroma;
           }
         } else {
+          // Otherwise the chroma overshoots the gamut boundary—reduce the
+          // interval and continue the binary search.
           max = chroma;
         }
       }
@@ -378,13 +403,24 @@
         totalConcentration = 0;
 
       for (let [color, factor] of colors) {
+        // Compute the effective pigment concentration for this band. Squaring
+        // the user-supplied factor and tinting strength accentuates their
+        // influence while preserving sign, and multiplying by the CIE Y
+        // component approximates the thickness weighting described in the
+        // Kubelka–Munk derivation.
         let concentration = factor ** 2 * color.tintingStrength ** 2 * color.luminance;
 
         totalConcentration += concentration;
 
+        // Mix in the absorption/scattering ratio of the color weighted by its
+        // concentration. The resulting sum is normalised by the total
+        // concentration before the inverse Kubelka–Munk transform is applied.
         ksMix += color.KS[i] * concentration;
       }
 
+      // Prevent division by zero when all concentrations vanish (for example
+      // when mixing multiple black colors) by relying on the epsilon embedded
+      // in the source reflectance data.
       R[i] = KM(ksMix / totalConcentration);
     }
 
@@ -582,11 +618,16 @@
   const lRGB_to_R = (lRGB) => {
     let w = Math.min(...lRGB);
 
+    // Extract the neutral (white) component shared by all three channels. The
+    // Kubelka–Munk basis includes an explicit white spectrum so we can subtract
+    // this term before resolving the chromatic contributions.
     lRGB = [lRGB[0] - w, lRGB[1] - w, lRGB[2] - w];
 
     let c = Math.min(lRGB[1], lRGB[2]);
     let m = Math.min(lRGB[0], lRGB[2]);
     let y = Math.min(lRGB[0], lRGB[1]);
+    // Residual single-channel contributions map onto the red, green and blue
+    // primaries that complete the spectral basis.
     let r = Math.max(0, Math.min(lRGB[0] - lRGB[2], lRGB[0] - lRGB[1]));
     let g = Math.max(0, Math.min(lRGB[1] - lRGB[2], lRGB[1] - lRGB[0]));
     let b = Math.max(0, Math.min(lRGB[2] - lRGB[1], lRGB[2] - lRGB[0]));


### PR DESCRIPTION
## Summary
- add a comprehensive overview of the Kubelka–Munk based mixing workflow for both the JS and GLSL builds
- expand inline commentary in `spectral.js` to clarify spectral reconstruction, gamut mapping, and mixing steps
- mirror the explanatory comments in `shader/spectral.glsl` so the GPU path documents its constants and transforms

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce63e42ab8832696d59dc0fb964b19